### PR TITLE
MAJOR: testing if semantic-version works

### DIFF
--- a/.github/workflows/dotnet-prerelease.yml
+++ b/.github/workflows/dotnet-prerelease.yml
@@ -34,7 +34,7 @@ jobs:
         -p:Version=${{ steps.version.outputs.version }} 
         --no-restore
 
-    - name: Publish Nuget to Github endpoint
+    - name: Publish Nuget
       run: >-
         dotnet nuget push 
         --api-key ${{ secrets.NUGET_PACKAGES_PAT }}


### PR DESCRIPTION
Pipeline yaml is using paulhatch/semantic-version extension to determine the semantic version of the package through parsing the PR title. Testing if having 'MAJOR' tag works as intended.